### PR TITLE
Add boolean atom

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ module.exports = (function(undefined) {
         return wrapRoot(obj.toString());
       case 'string':
       case 'number':
+      case 'boolean':
         return util.inspect(obj);
     }
 


### PR DESCRIPTION
Previously, objects with a boolean value were considered to have a circular
reference.
